### PR TITLE
dash: add dashboard to display top 10 repo by price

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -22,6 +22,7 @@ plugins:
         autorefresh: false
       layout:
         - [actions-top-repo-minutes-bar, actions-top-repo-minutes-bar]
+        - [actions-top-repo-price-bar, actions-top-repo-price-bar]
         - [actions-top-repo-minutes, actions-top-repo-price]
         - [actions-minutes-monthly-tracker, actions-minutes-daily-tracker]
         - [runner-types-ranking, actions-run-daily]
@@ -81,6 +82,50 @@ plugins:
             encoding:
               y: { field: repo, type: nominal, sort: -x }
               x: { aggregate: sum, field: quantity }
+              color: { field: workflow, type: nominal }
+              opacity:
+                condition: { param: highlight, value: 1 }
+                value: 0.2
+
+        actions-top-repo-price-bar:
+          title: Top 10 repositories by price
+          db: usage
+          query: >-
+            SELECT
+              Owner || "/" || "Repository Slug" as repo,
+              Owner || "/" || "Repository Slug" || "/" || "Actions Workflow" as workflow,
+              price
+            FROM usage
+            WHERE (Owner || "/" || "Repository Slug") IN (
+                SELECT repo
+                FROM (
+                  SELECT
+                    Owner || "/" || "Repository Slug" as repo,
+                    SUM(price) as total_price
+                  FROM usage
+                  WHERE Product = 'Actions'
+                    [[ AND date >= date(:date_start) ]]
+                    [[ AND date <= date(:date_end) ]]
+                    [[ AND owner = :owner ]]
+                  GROUP BY repo
+                  ORDER BY total_price DESC
+                  LIMIT 10
+                )
+              )
+              AND Product = 'Actions'
+              [[ AND date >= date(:date_start) ]]
+              [[ AND date <= date(:date_end) ]]
+              [[ AND owner = :owner ]]
+          library: vega-lite
+          display:
+            mark: { type: bar, tooltip: true }
+            params:
+              - name: highlight
+                select: { fields: [workflow], type: point, "on": mouseover }
+                bind: legend
+            encoding:
+              y: { field: repo, type: nominal, sort: -x }
+              x: { aggregate: sum, field: price }
               color: { field: workflow, type: nominal }
               opacity:
                 condition: { param: highlight, value: 1 }


### PR DESCRIPTION
This pull request introduces changes to the `metadata.yml` file, specifically in the `plugins:` section. The changes involve the addition of a new layout element `actions-top-repo-price-bar` and the corresponding query and display settings for this element.

Here are the key changes:

* [`metadata.yml`](diffhunk://#diff-c367683786fd98a0bdc160c6dcd37f8d75c0bbaf359290b15cf32759afbbe504R25): Added a new layout element `actions-top-repo-price-bar` to the existing layout configuration. This element is expected to display the top 10 repositories by price.
* [`metadata.yml`](diffhunk://#diff-c367683786fd98a0bdc160c6dcd37f8d75c0bbaf359290b15cf32759afbbe504R90-R133): Introduced the query and display settings for `actions-top-repo-price-bar`. The query retrieves data about the top 10 repositories by price from the 'usage' database. The display settings include a bar type mark with a tooltip, and encoding settings for the 'repo', 'price', and 'workflow' fields.